### PR TITLE
Fix shape issues with train_target for copy_task

### DIFF
--- a/copy_task.py
+++ b/copy_task.py
@@ -31,7 +31,7 @@ def getTask(N_BATCH, SEQ_LENGTH, FEAT_SIZE, BLANK_SIZE, embedding):
     for i in range(N_BATCH):
 
         # Target values of blank and delim
-        blank = FEAT_SIZE 
+        blank = np.array([FEAT_SIZE])
         delim = FEAT_SIZE + 1
 
         # Embedding

--- a/recurrent_models.py
+++ b/recurrent_models.py
@@ -140,6 +140,24 @@ class QLSTM(nn.Module):
      
         return torch.cat(out,0)
 
+class StackedQLSTM(nn.Module):
+    def __init__(self, feat_size, hidden_size, use_cuda, n_layers, batch_first=True):
+        super(StackedQLSTM, self).__init__()
+        self.batch_first = batch_first
+        self.layers = nn.ModuleList([QLSTM(feat_size, hidden_size, use_cuda) for _ in range(n_layers)])
+    
+    def forward(self, x):
+        # QLSTM takes inputs of shape (seq_len, batch_size, feat_size)
+        if self.batch_first:
+            x = x.permute(1,0,2)
+        for layer in self.layers:
+            x = layer(x)
+            # Remove extra feature added by QLSTM
+            x = x[:,:,:-1]
+        if self.batch_first:
+            x = x.permute(1,0,2)
+        return x
+
 class RNN(nn.Module):
     def __init__(self, feat_size, hidden_size, CUDA):
         super(RNN, self).__init__()

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,34 @@
+import torch
+import unittest
+
+from recurrent_models import StackedQLSTM
+
+class TestStackedQLSTM(unittest.TestCase):
+    feat_size = 4 # Must be multiple of 4
+    batch_size = 2
+    seq_len = 5
+    hidden_size = 16 # Must be multiple of 4
+
+    def test_train(self):
+        lstm = StackedQLSTM(self.feat_size, self.hidden_size, False, 2, True)
+        inputs = torch.ones((self.batch_size, self.seq_len, self.feat_size))
+
+        optimizer = torch.optim.SGD(lstm.parameters(), lr=0.001)
+        lstm.train()
+
+        init_loss = None
+
+        for i in range(50):
+            optimizer.zero_grad()
+            outputs = lstm(inputs)
+            loss = torch.nn.L1Loss()(outputs, torch.ones(outputs.size()))
+            if init_loss is None:
+                init_loss = loss.item()
+            loss.backward()
+            optimizer.step()
+            print("Loss: {}".format(loss.item()))
+
+        self.assertLess(loss.item(), init_loss)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
On my system, `train_target_var = tovar(train_target)` threw a TypeError:

> Traceback (most recent call last):
  File "C:/Users/alt/Desktop/playground/Pytorch-Quaternion-Neural-Networks/copy_task.py", line 138, in <module>
    train_target_var = tovar(train_target)
  File "C:/Users/alt/Desktop/playground/Pytorch-Quaternion-Neural-Networks/copy_task.py", line 23, in tovar
    return Variable(torch.FloatTensor(x).cuda())
TypeError: can't convert np.ndarray of type numpy.object_. The only supported types are: float64, float32, float16, int64, int32, int16, int8, and uint8.

I fixed this by making "blank" a 1D-array instead of a scalar.
